### PR TITLE
Update error naming conventions to PascalCase

### DIFF
--- a/sources/bonding_curve.move
+++ b/sources/bonding_curve.move
@@ -1,8 +1,8 @@
 module bond_craft::bonding_curve {
     
     // Constants for error codes
-    const EDIVISION_BY_ZERO: u64 = 1000;
-    const EOVERFLOW: u64 = 1001;
+    const EDivisionByZero: u64 = 1000;
+    const EOverflow: u64 = 1001;
 
     // Scaling factor to handle precision in calculations
     const SCALING_FACTOR: u64 = 1_000_000_000; // 10^9 for precision
@@ -15,7 +15,7 @@ module bond_craft::bonding_curve {
         max_tokens: u64,
         token_decimals: u8
         ): u64 {
-        assert!(max_tokens != 0, EDIVISION_BY_ZERO);
+        assert!(max_tokens != 0, EDivisionByZero);
 
         // Convert to base units using u8 exponents
         let funding_goal_base = (funding_goal as u128) * (10u128).pow(funding_decimals);
@@ -24,11 +24,11 @@ module bond_craft::bonding_curve {
         let numerator = 2u128 * funding_goal_base * (SCALING_FACTOR as u128);
         let denominator = max_tokens_base * max_tokens_base;
 
-        assert!(denominator != 0, EDIVISION_BY_ZERO);
+        assert!(denominator != 0, EDivisionByZero);
         let k = numerator / denominator;
 
         // Use literal for u64 max value
-        assert!(k <= 18446744073709551615u128, EOVERFLOW);
+        assert!(k <= 18446744073709551615u128, EOverflow);
 
         (k as u64)
     }
@@ -45,7 +45,7 @@ module bond_craft::bonding_curve {
         let price = ((k as u128) * tokens_sold_base) / 1_000_000_000u128;
         
         // Use literal instead of u64::MAX
-        assert!(price <= 18446744073709551615u128, EOVERFLOW);
+        assert!(price <= 18446744073709551615u128, EOverflow);
 
         (price as u64)
     }

--- a/sources/factory.move
+++ b/sources/factory.move
@@ -4,11 +4,11 @@ module bond_craft::factory{
     use sui::event;
 
     // Error codes
-    const ENOT_FOUND: u64 = 0;
-    const EINVALID_SUPPLY: u64 = 1;
-    const EINVALID_NAME: u64 = 2;
-    const EINVALID_SYMBOL: u64 = 3;
-    const EINVALID_DECIMALS: u64 = 4;
+    const ENotFound: u64 = 0;
+    const EInvalidSupply: u64 = 1;
+    const EInvalidName: u64 = 2;
+    const EInvalidSymbol: u64 = 3;
+    const EInvalidDecimals: u64 = 4;
 
     public struct LaunchpadFactory has key {
         id: UID,
@@ -72,11 +72,11 @@ module bond_craft::factory{
     ) {
         assert!(
             funding_tokens + creator_tokens + liquidity_tokens + platform_tokens == total_supply,
-            EINVALID_SUPPLY
+            EInvalidSupply
         );
-        assert!(&name != vector::empty<u8>(), EINVALID_NAME);
-        assert!(&symbol != vector::empty<u8>(), EINVALID_SYMBOL);
-        assert!(decimals >= 6, EINVALID_DECIMALS);
+        assert!(&name != vector::empty<u8>(), EInvalidName);
+        assert!(&symbol != vector::empty<u8>(), EInvalidSymbol);
+        assert!(decimals >= 6, EInvalidDecimals);
         
         let creator = tx_context::sender(ctx);
         let platform_admin = creator;
@@ -147,7 +147,7 @@ module bond_craft::factory{
         factory: &LaunchpadFactory,
         creator: address
     ): &vector<ID> {
-        assert!(table::contains(&factory.launchpads, creator), ENOT_FOUND);
+        assert!(table::contains(&factory.launchpads, creator), ENotFound);
         table::borrow(&factory.launchpads, creator)
     }
 

--- a/sources/pool.move
+++ b/sources/pool.move
@@ -12,12 +12,12 @@ module bond_craft::pool{
     use integer_mate::i32::{Self, I32};
 
     // Error codes
-    const EINVALID_TICK_RANGE: u64 = 1;
-    const EINVALID_LIQUIDITY: u64 = 2;
-    const EINVALID_TICK_SPACING: u64 = 3;
-    const ETICK_NOT_ALIGNED: u64 = 4;
-    const EINSUFFICIENT_LIQUIDITY: u64 = 5;
-    const EINVALID_PRICE: u64 = 6;
+    const EInvalidTickRange: u64 = 1;
+    const EInvalidLiquidity: u64 = 2;
+    const EInvalidTickSpacing: u64 = 3;
+    const ETickNotAligned: u64 = 4;
+    const EInsufficientLiquidity: u64 = 5;
+    const EInvalidPrice: u64 = 6;
 
     // Events
     public struct PoolCreatedEvent has copy, drop {
@@ -46,7 +46,7 @@ module bond_craft::pool{
 
         // Calculate sqrt(price) * 2^96
         // Since sqrt requires u64, ensure adjusted_price is within bounds
-        assert!(adjusted_price <= 0xFFFFFFFFFFFFFFFF, EINVALID_PRICE); // Ensure no overflow
+        assert!(adjusted_price <= 0xFFFFFFFFFFFFFFFF, EInvalidPrice); // Ensure no overflow
         let sqrt_price = (math::sqrt(adjusted_price) as u128) * (1u128 << 96);
 
         // Clamp sqrt_price to Cetus bounds
@@ -95,7 +95,7 @@ module bond_craft::pool{
         clock: &Clock,
         ctx: &mut TxContext
     ) {
-        assert!(tick_spacing == 100 || tick_spacing == 500 || tick_spacing == 3000, EINVALID_TICK_SPACING);
+        assert!(tick_spacing == 100 || tick_spacing == 500 || tick_spacing == 3000, EInvalidTickSpacing);
 
         // Calculate tick from price
         let tick = price_to_tick(final_price, 9, 6);
@@ -108,18 +108,18 @@ module bond_craft::pool{
         // Validate tick range
         assert!(
             i32::gte(tick_lower, tick_math::min_tick()) && i32::lte(tick_upper, tick_math::max_tick()),
-            EINVALID_TICK_RANGE
+            EInvalidTickRange
         );
 
         // Ensure ticks are aligned with tick_spacing
-        assert!(tick_math::is_valid_index(tick_lower, tick_spacing), ETICK_NOT_ALIGNED);
-        assert!(tick_math::is_valid_index(tick_upper, tick_spacing), ETICK_NOT_ALIGNED);
+        assert!(tick_math::is_valid_index(tick_lower, tick_spacing), ETickNotAligned);
+        assert!(tick_math::is_valid_index(tick_upper, tick_spacing), ETickNotAligned);
 
         // Validate liquidity
         let token_value = coin::value(&token);
         let usdc_value = coin::value(&usdc);
-        assert!(token_value > 0 && usdc_value > 0, EINVALID_LIQUIDITY);
-        assert!(token_value >= 1000 && usdc_value >= 1000, EINSUFFICIENT_LIQUIDITY);
+        assert!(token_value > 0 && usdc_value > 0, EInvalidLiquidity);
+        assert!(token_value >= 1000 && usdc_value >= 1000, EInsufficientLiquidity);
 
         // Convert ticks to u32 for create_pool_v2
         let tick_lower_u32 = i32::as_u32(i32::abs(tick_lower));
@@ -175,8 +175,8 @@ module bond_craft::pool{
         ctx: &mut TxContext
     ) {
         // Validate inputs (mimic create_pool logic)
-        assert!(tick_spacing == 100 || tick_spacing == 500 || tick_spacing == 3000, EINVALID_TICK_SPACING);
-        assert!(coin::value(&token) >= 1000 && coin::value(&usdc) >= 1000, EINSUFFICIENT_LIQUIDITY);
+        assert!(tick_spacing == 100 || tick_spacing == 500 || tick_spacing == 3000, EInvalidTickSpacing);
+        assert!(coin::value(&token) >= 1000 && coin::value(&usdc) >= 1000, EInsufficientLiquidity);
 
         // Simulate pool creation by transferring coins back
         let sender = tx_context::sender(ctx);


### PR DESCRIPTION
Refactor error naming in multiple modules to follow PascalCase conventions for consistency and improved readability.